### PR TITLE
todo, todo-detail response 에 1초 delay

### DIFF
--- a/consts/delay.ts
+++ b/consts/delay.ts
@@ -1,0 +1,4 @@
+/**
+ * MS : 밀리 초 (1000ms == 1초)
+ */
+export const responseDelayMS = 1000;

--- a/controllers/todoController.ts
+++ b/controllers/todoController.ts
@@ -5,6 +5,7 @@ import * as todoService from "../services/todoService";
 import { createError, createResponse } from "../utils/responseUtils";
 import { TODO_VALIDATION_ERRORS } from "../utils/validator";
 import type { TodoInput } from "../types/todos";
+import { responseDelayMS } from '../consts/delay';
 
 export const createTodo = async (req: Request, res: Response) => {
   const { title, content }: TodoInput = req.body;
@@ -26,10 +27,12 @@ export const getTodos = async (req: Request, res: Response) => {
   const todos = todoService.findTodos();
 
   if (todos) {
-    if (countOnly) {
-      return res.status(StatusCodes.OK).send(createResponse(todos.length));
-    }
-    return res.status(StatusCodes.OK).send(createResponse(todos));
+      setTimeout(() => {
+        if (countOnly) {
+            return res.status(StatusCodes.OK).send(createResponse(todos.length));
+          }
+          return res.status(StatusCodes.OK).send(createResponse(todos));
+      }, responseDelayMS);
   } else {
     return res
       .status(StatusCodes.BAD_REQUEST)
@@ -43,7 +46,9 @@ export const getTodoById = (req: Request, res: Response) => {
   const todo = todoService.findTodo((todo) => todo.id === todoId);
 
   if (todo) {
-    return res.status(StatusCodes.OK).send(createResponse(todo));
+      setTimeout(() => {
+        return res.status(StatusCodes.OK).send(createResponse(todo));
+      }, responseDelayMS);
   } else {
     return res
       .status(StatusCodes.BAD_REQUEST)


### PR DESCRIPTION
todo(list), todo detail 에 delay를 줍니다.

react-query 에서 isLoading 에 대한 학습을 할 때 좋을 것 같아 PR 올립니다.
(isLoading == true 일 때에 로딩중 화면을 띄울 때에 대해)

동영상 예시의 설정 
- api 쿼리 delay
- react-query cacheTime 2초 및 staleTime 5초 설정

동영상 예시의 테스트 과정 
1. 첫 todoList 로딩 시 - 1초 딜레이 이후 todoList 렌더링
2. 이후 로딩 시 - 딜레이 없이 todoList 렌더링 (cache)
3. 5초 간 todoList 화면에서 벗어난 뒤 다시 로딩 시 - 1초 딜레이 이후 렌더링

https://user-images.githubusercontent.com/12489026/214211988-de0219b5-5a0c-4124-97d8-4584b8e266c1.mov

